### PR TITLE
Take screenshot from Primary window when using multiple monitors

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ function getScreen(callback) {
             var ctx = canvas.getContext('2d');
             // Draw video on canvas
             ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-            
+
             if (_this.callback) {
                 // Save screenshot to jpg - base64
                 _this.callback(canvas.toDataURL('image/jpeg'));
@@ -50,7 +50,7 @@ function getScreen(callback) {
         // console.log(sources);
         for (let i = 0; i < sources.length; ++i) {
             // Filter: main screen
-            if (sources[i].name === "Entire screen") {
+            if (sources[i].name === "Entire screen" || sources[i].name === "Screen 1") {
                 navigator.webkitGetUserMedia({
                     audio: false,
                     video: {


### PR DESCRIPTION
When using multiple monitors, the script couldn't detect any monitor as when using multiple monitors, it never returns the `Entire screen` as the source name. So, I've fixed the issue.

Now when there are multiple monitors, the script will take screenshot from the primary monitor.